### PR TITLE
config file using integrant and aero

### DIFF
--- a/config/dev.edn
+++ b/config/dev.edn
@@ -1,0 +1,3 @@
+{
+ :framework.db.storage/postgresql {:port 5432}
+ }

--- a/config/main.edn
+++ b/config/main.edn
@@ -1,0 +1,3 @@
+{
+ :framework #profile {:dev #include "dev.edn"}
+ }

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,10 @@
   :description "Framework"
   :url "https://github.com/Flexiana/framework"
   :license {:name "FIXME" :url "FIXME"}
-  :dependencies [[org.clojure/clojure "1.10.1"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [integrant "0.8.0"]
+                 [aero "1.1.6"]]
   :target "target/%s/"
+  :resource-paths ["resources" "config"]
   :main framework.components.core
   )

--- a/src/framework/components/core.clj
+++ b/src/framework/components/core.clj
@@ -1,5 +1,12 @@
-(ns framework.components.core)
+(ns framework.components.core
+  (:require [integrant.core :as ig]
+            [framework.db.storage]
+            [framework.config.core :as config]))
 
 (defn -main
   [& args]
-  (println "Hello World!"))
+  (let [profile (keyword (or (System/getenv "PROFILE") "dev"))
+        system (ig/init (config/edn profile))]
+    (.addShutdownHook
+      (Runtime/getRuntime)
+      (Thread. ^Runnable (ig/halt! system)))))

--- a/src/framework/config/core.clj
+++ b/src/framework/config/core.clj
@@ -1,0 +1,13 @@
+(ns framework.config.core
+  (:require [integrant.core :as ig]
+            [aero.core :as aero]
+            [clojure.java.io :as io]))
+
+(defmethod aero/reader 'ig/ref
+  [_ tag value]
+  (ig/ref value))
+
+(defn edn
+  [profile]
+  (:framework
+   (aero/read-config (io/resource "main.edn") {:profile profile})))

--- a/src/framework/db/storage.clj
+++ b/src/framework/db/storage.clj
@@ -1,0 +1,10 @@
+(ns framework.db.storage
+  (:require [integrant.core :as ig]))
+
+(defmethod ig/init-key ::postgresql
+  [_ cfg]
+  (println "Start Postgresql " cfg))
+
+(defmethod ig/halt-key! ::postgresql
+  [_ cfg]
+  (println "Stop Postgresql"))


### PR DESCRIPTION
I would like to show you how `aero` and `integrant` can work together. @yatagan I tried to mimic the functionality to keep configurations in different files based on profiles.

For aero, profiles are just keywords you will pass during the read stage (namespace framework.config.core) they are not related to leiningen profiles.

