### PR TITLE
Exchange the POST and PUT http methods

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.flexiana/framework "0.2.1"
+(defproject com.flexiana/framework "0.2.2"
   :description "Framework"
   :url "https://github.com/Flexiana/framework"
   :license {:name "FIXME" :url "FIXME"}

--- a/src/framework/acl/core.clj
+++ b/src/framework/acl/core.clj
@@ -6,8 +6,8 @@
 
 (def action-mapping
   {:get    :read
-   :post   :update
-   :put    :create
+   :post   :create
+   :put    :update
    :delete :delete})
 
 (defn- ->resource
@@ -35,8 +35,8 @@
   |req:    | action: |
   |------- |---------|
   |:get    | :read   |
-  |:post   | :update |
-  |:put    | :create |
+  |:post   | :create |
+  |:put    | :update |
   |:delete | :delete |"
   ([{{user :user}             :session-data
      roles                    :acl/roles

--- a/test/framework/acl/core_test.clj
+++ b/test/framework/acl/core_test.clj
@@ -115,6 +115,10 @@
          (get-error (is-allowed (state-with-user-request guest "/items/" :post)))))
   (is (= :own
          (get-ok (is-allowed (state-with-user-request member "/addresses/" :post)))))
+  (is (= :own
+         (get-ok (is-allowed (state-with-user-request member "/users/" :put)))))
+  (is (= {:status 401, :body "Authorization error"}
+         (get-error (is-allowed (state-with-user-request member "/users/" :post)))))
   (is (= :all
          (get-ok (is-allowed (state-with-user-request admin "/items/" :get)))))
   (is (= :all


### PR DESCRIPTION
The already implemented endpoints use the PUT http method for creating a resource and POST for updating it. This is against the convention that is followed by the industry. We need to use the POST http method for creating a resource and PUT for updating it.