### PR TITLE
remove print in handler

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.flexiana/framework "0.2.2"
+(defproject com.flexiana/framework "0.2.3"
   :description "Framework"
   :url "https://github.com/Flexiana/framework"
   :license {:name "FIXME" :url "FIXME"}

--- a/src/framework/components/web_server/core.clj
+++ b/src/framework/components/web_server/core.clj
@@ -91,9 +91,6 @@
         (runner/run router-interceptors route)
         (additional-interceptors controller-interceptors run-controller))
       (xiana/extract)
-      ((fn [x]
-         (println x)
-         x))
       (get :response))))
 
 (defn ->web-server


### PR DESCRIPTION
https://www.notion.so/flexiana/84c5d7907e8249a09ce5a60ff0f67b43?v=5fcfbc9a774c471d88ad46bf5ef11b9e&p=e6d75b780a1c4fe29981cfcacac5d822

**Why**

"We all hate that log" (c) Juan Ignacio Lopez

I deleted a `prn` func which prints all request data on every request. It made my developer experience very sad: my repl emacs buffer had tens of MBs of data after a short period of work and emacs was dying constantly when a request body was big (files). 
I have been using reifyhealth/lein-git-down plugin locally, which allows specifying specific commit as a dependency, to work around this issue, but I couldn't make it work with our CI (Github Actions). 

So it seems the easiest way is to merge this change into `main` and upload the new version to clojars.