### PR TITLE
Fixing SSE and cookies bugs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.flexiana/framework "0.3.0"
+(defproject com.flexiana/framework "0.3.1"
   :description "Framework"
   :url "https://github.com/Flexiana/framework"
   :license {:name "FIXME" :url "FIXME"}

--- a/src/framework/cookies/core.clj
+++ b/src/framework/cookies/core.clj
@@ -5,20 +5,24 @@
     [ring.middleware.cookies :as cookies]
     [xiana.core :as xiana]))
 
-(defn- parse-request-cookies
-  [req]
-  (keywordize-keys
-    (cookies/cookies-request req)))
-
-(defn- parse-response-cookies
-  [resp]
-  (cookies/cookies-response resp))
-
 (def interceptor
   "Parses request and response cookies"
-  {:enter (fn [state]
-            (xiana/ok
-              (update state :request
-                      parse-request-cookies)))
-   :exit  (fn [state]
-            (xiana/ok (update state :response parse-response-cookies)))})
+  (letfn [(move-cookies
+            [req]
+            (if (get-in req [:headers "cookie"])
+              req
+              (assoc-in req [:headers "cookie"]
+                        (get-in req [:headers :cookie]))))
+          (parse-request-cookies
+            [req]
+            (keywordize-keys
+              (cookies/cookies-request (move-cookies req))))
+          (parse-response-cookies
+            [resp]
+            (cookies/cookies-response resp))]
+    {:enter (fn [state]
+              (xiana/ok
+                (update state :request
+                        parse-request-cookies)))
+     :leave (fn [state]
+              (xiana/ok (update state :response parse-response-cookies)))}))

--- a/src/framework/sse/core.clj
+++ b/src/framework/sse/core.clj
@@ -22,7 +22,7 @@
   (close [this]
     (.close! (:channel this))
     (doseq [c @(:clients this)]
-      (.close c))))
+      (server/close c))))
 
 (defn init [config]
   (let [channel (async/chan 5)
@@ -42,7 +42,8 @@
     (server/as-channel (:request state)
                        {:init       (fn [ch]
                                       (swap! clients conj ch)
-                                      (server/send! ch {:headers headers} false))
+                                      (server/send! ch {:headers headers
+                                                        :body (json/write-str {})}) false)
                         :on-receive (fn [ch message])
                         :on-ping    (fn [ch data])
                         :on-close   (fn [ch status] (swap! clients disj ch))


### PR DESCRIPTION
## Title: 

Updating framework version to v0.3.1

### Description
Fix for found bugs in SSE and cookies modules

### Tester info
 - Cookies should be stored in browser, when it's injected to (-> state :response :cookies]).
 - SSE channels must be closed on (user/stop-dev-system).
 - SSE should open an async channel with (js/WebSocket. url) function.