### PR TITLE
Fix typos in doc/intro.md

### DIFF
--- a/doc/intro.md
+++ b/doc/intro.md
@@ -39,5 +39,5 @@ If you'd like to define some of them, their keys are: `:bcrypt :scrypt :pbkdf2`.
                                        :iterations 100000}}
 ```
 
-The module has `make` (it generate a hashed password) and `check` (it verify encrypted password against current string) functions to deal with hashing process.
+The module has `make` (it generate a hashed password) and `check` (it verifies the encrypted password against the current string) functions to deal with hashing process.
 

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -27,7 +27,7 @@ Full configuration looks like this
 ## Hashing
 
 The module `framework.auth.hash` provides secure Bcrypt, Scrypt and Pbkdf2 hashing for storing user passwords.
-If you'd like to define someone of them, their keys are: `:bcrypt :scrypt :pbkdf2`. If you don't define one of them, Bcrypt will be defined by default. You can setup the key within `config` derectory as well as its corresponding optional configuration. The values by default for each algorithm are defined as follows:
+If you'd like to define some of them, their keys are: `:bcrypt :scrypt :pbkdf2`. If you don't define one of them, Bcrypt will be defined by default. You can setup the key within `config` derectory as well as its corresponding optional configuration. The values by default for each algorithm are defined as follows:
 
 ```clojure
 :framework.app/auth {:hash-algorithm :bcrypt ;; Available values: :bcrypt, :scrypt, and :pbkdf2
@@ -39,5 +39,5 @@ If you'd like to define someone of them, their keys are: `:bcrypt :scrypt :pbkdf
                                        :iterations 100000}}
 ```
 
-The module has `make` (it generate a hashed password) and `check` (it verify encripted password with current string) functions to deal hashing process.
+The module has `make` (it generate a hashed password) and `check` (it verify encrypted password against current string) functions to deal with hashing process.
 


### PR DESCRIPTION
## Title: Fix typos in doc/intro.md

### Description

Fix some typos in `doc/intro.md`