### PR TITLE
Bugfix in coercion to resolve request-method response schemas

### DIFF
--- a/examples/acl/project.clj
+++ b/examples/acl/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.3.4"]
+                 [com.flexiana/framework "0.3.5"]
                  [thheller/shadow-cljs "2.11.7"]
                  [migratus "1.3.5"]
                  [clj-http "3.12.0"]

--- a/examples/cli-chat/project.clj
+++ b/examples/cli-chat/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.3.4"]
+                 [com.flexiana/framework "0.3.5"]
                  [thheller/shadow-cljs "2.11.26"]
                  [migratus "1.3.5"]
                  [clj-http "3.12.1"]

--- a/examples/controllers/project.clj
+++ b/examples/controllers/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.flexiana/framework "0.3.4"]
+                 [com.flexiana/framework "0.3.5"]
                  [metosin/reitit "0.5.15"]
                  [metosin/malli "0.6.2"]
                  [duct/server.http.jetty "0.2.1"]

--- a/examples/frames/project.clj
+++ b/examples/frames/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.flexiana/framework "0.3.4"]
+                 [com.flexiana/framework "0.3.5"]
                  [com.flexiana/corpus "0.1.3"]
                  [thheller/shadow-cljs "2.11.7"]
                  [reagent "0.10.0"]

--- a/examples/sessions/project.clj
+++ b/examples/sessions/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.flexiana/framework "0.3.4"]
+                 [com.flexiana/framework "0.3.5"]
                  [metosin/reitit "0.5.6"]
                  [duct/server.http.jetty "0.2.1"]
                  [thheller/shadow-cljs "2.11.7"]

--- a/examples/state-events/project.clj
+++ b/examples/state-events/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.3.4"]
+                 [com.flexiana/framework "0.3.5"]
                  [thheller/shadow-cljs "2.11.26"]
                  [cljs-ajax "0.8.4"]
                  [org.clojure/tools.namespace "1.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.flexiana/framework "0.3.4"
+(defproject com.flexiana/framework "0.3.5"
   :description "Framework"
   :url "https://github.com/Flexiana/framework"
   :license {:name "FIXME" :url "FIXME"}

--- a/src/framework/coercion/core.clj
+++ b/src/framework/coercion/core.clj
@@ -48,9 +48,11 @@
    :error (fn [state]
             (xiana/error (assoc state :response {:status 400
                                                  :body   "Request coercion failed"})))
-   :leave (fn [{{:keys [:status :body]} :response
-                :as                     state}]
-            (let [schema (get-in state [:request-data :match :data :responses status :body])]
+   :leave (fn [{{:keys [:status :body]}  :response
+                {method :request-method} :request
+                :as                      state}]
+            (let [schema (or (get-in state [:request-data :match :data method :responses status :body])
+                             (get-in state [:request-data :match :data :responses status :body]))]
               (cond (and schema body (m/validate schema body)) (xiana/ok state)
                     (and schema body) (xiana/error (assoc state :response {:status 400
                                                                            :body   "Response validation failed"}))


### PR DESCRIPTION
## Title: Coercion response validation schema doesn't get validated, when it was specified for request method


### Description
Read it as primary, fall back to path specification 

Everything should be the same