### PR TITLE
Alter protected-interceptor param

### DIFF
--- a/doc/tutorials.md
+++ b/doc/tutorials.md
@@ -54,7 +54,7 @@ The system configuration and start-up with the chainable set-up:
    :controller-interceptors (concat [(xiana-interceptors/muuntaja)
                                      cookies/interceptor
                                      xiana-interceptors/params
-                                     (session/protected-interceptor "/api" "/login")
+                                     (session/protected-interceptor "/api" ["/login"])
                                      xiana-interceptors/view
                                      xiana-interceptors/side-effect
                                      db/db-access]

--- a/examples/sessions/src/backend/app/core.clj
+++ b/examples/sessions/src/backend/app/core.clj
@@ -38,7 +38,7 @@
 (def app-cfg
   {:routes routes
    :controller-interceptors [x-interceptors/params
-                             (x-session/protected-interceptor "" "/login")]})
+                             (x-session/protected-interceptor "" ["/login"])]})
 
 (defn -main
   [& _args]

--- a/src/framework/session/core.clj
+++ b/src/framework/session/core.clj
@@ -164,13 +164,19 @@
                                    :body   (json/write-value-as-string
                                              {:message "Invalid or missing session"})})))))
 
+(defn- check-excluded-resources
+  [protected-path excluded-resources uri]
+  (not (some (fn [resources]
+               (= uri (str protected-path resources)))
+             excluded-resources)))
+
 (defn- protect
   [protected-path
-   excluded-resource
+   excluded-resources
    {{uri :uri} :request
     :as        state}]
   (if (and (string/starts-with? uri protected-path)
-           (not= uri (str protected-path excluded-resource)))
+           (check-excluded-resources protected-path excluded-resources uri))
     (on-enter state)
     (xiana/ok state)))
 
@@ -198,8 +204,8 @@
                        :body   \"Invalid or missing session\"}
    
    On leave, it updates the session storage from (-> state :session-data)"
-  [protected-path excluded-resource]
-  {:enter (partial protect protected-path excluded-resource)
+  [protected-path excluded-resources]
+  {:enter (partial protect protected-path excluded-resources)
    :leave on-leave})
 
 (def interceptor

--- a/src/framework/session/core.clj
+++ b/src/framework/session/core.clj
@@ -166,17 +166,17 @@
 
 (defn- check-excluded-resources
   [protected-path excluded-resources uri]
-  (not (some (fn [resources]
-               (= uri (str protected-path resources)))
-             excluded-resources)))
+  (and (string/starts-with? uri protected-path)
+       (not (some (fn [resources]
+                    (= uri (str protected-path resources)))
+                  excluded-resources))))
 
 (defn- protect
   [protected-path
    excluded-resources
    {{uri :uri} :request
     :as        state}]
-  (if (and (string/starts-with? uri protected-path)
-           (check-excluded-resources protected-path excluded-resources uri))
+  (if (check-excluded-resources protected-path excluded-resources uri)
     (on-enter state)
     (xiana/ok state)))
 

--- a/test/framework/web_socket/integration_test.clj
+++ b/test/framework/web_socket/integration_test.clj
@@ -45,7 +45,7 @@
   {:routes                   routes
    :web-socket-interceptors  [interceptors/params]
    :controller-interceptors  [interceptors/params
-                              (session/protected-interceptor "/api" "/login")
+                              (session/protected-interceptor "/api" ["/login"])
                               rbac/interceptor]})
 
 (use-fixtures :once (partial fixture/std-system-fixture system-config))


### PR DESCRIPTION
## Title:  Alter protected-interceptor param

### Description
Allow `protected-interceptor` to receive a list of excluded-resources,. Useful for having more than one login route (for allowing either oauth or native logins) 

### Tester info
tests should pass with the modifications done to the code.
