### PR TITLE
Marshalling between Clj data and db PGobjects

### DIFF
--- a/examples/state-events/src/backend/state_events/controllers/event.clj
+++ b/examples/state-events/src/backend/state_events/controllers/event.clj
@@ -68,7 +68,7 @@
     (if (or (nil? last-event) (= "delete" last-action))
       (resource-exist-error state "Resource does not exists")
       (case action
-        "dissoc-key" (let [k (-> payload model/<-pgobject :remove)]
+        "dissoc-key" (let [k (:remove payload)]
                        (case k
                          "resource" (invalid-action state "Cannot delete resource type")
                          "id" (invalid-action state "Cannot delete id of resource")

--- a/src/framework/db/core.clj
+++ b/src/framework/db/core.clj
@@ -2,16 +2,70 @@
   "Data source builder"
   (:require
     [clj-test-containers.core :as tc]
+    [jsonista.core :as json]
     [honeysql-postgres.format]
     [honeysql.core :as sql]
     [migratus.core :as migratus]
     [next.jdbc :as jdbc]
+    [next.jdbc.prepare :as prepare]
+    [next.jdbc.result-set :as rs]
     [xiana.core :as xiana])
   (:import
+    (clojure.lang
+      IPersistentMap
+      IPersistentVector)
     (java.lang
       AutoCloseable)
+    (java.sql
+      PreparedStatement)
     (org.postgresql.jdbc
-      PgConnection)))
+      PgConnection)
+    (org.postgresql.util
+      PGobject)))
+
+(def mapper (json/object-mapper {:decode-key-fn keyword}))
+(def ->json json/write-value-as-string)
+(def <-json #(json/read-value % mapper))
+
+(defn ->pgobject
+  "Transforms Clojure data to a PGobject that contains the data as
+  JSON. PGObject type defaults to `jsonb` but can be changed via
+  metadata key `:pgtype`"
+  [x]
+  (let [pgtype (or (:pgtype (meta x)) "jsonb")]
+    (doto (PGobject.)
+      (.setType pgtype)
+      (.setValue (->json x)))))
+
+(defn <-pgobject
+  "Transform PGobject containing `json` or `jsonb` value to Clojure
+  data."
+  [^PGobject v]
+  (let [type (.getType v)
+        value (.getValue v)]
+    (if (#{"jsonb" "json"} type)
+      (some-> value
+              <-json
+              (with-meta {:pgtype type}))
+      value)))
+
+;; Hashmaps and vectors in queries will be converted to PGobject for JSON/JSONB
+(extend-protocol prepare/SettableParameter
+  IPersistentMap
+  (set-parameter [^IPersistentMap m ^PreparedStatement s i]
+    (.setObject s i (->pgobject m)))
+
+  IPersistentVector
+  (set-parameter [^IPersistentVector v ^PreparedStatement s i]
+    (.setObject s i (->pgobject v))))
+
+;; PGobject containing JSON/JSONB will be converted to Clojure data
+(extend-protocol rs/ReadableColumn
+  PGobject
+  (read-column-by-label [^PGobject v _]
+    (<-pgobject v))
+  (read-column-by-index [^PGobject v _ _]
+    (<-pgobject v)))
 
 (defrecord db
   [dbtype

--- a/src/framework/db/core.clj
+++ b/src/framework/db/core.clj
@@ -2,9 +2,9 @@
   "Data source builder"
   (:require
     [clj-test-containers.core :as tc]
-    [jsonista.core :as json]
     [honeysql-postgres.format]
     [honeysql.core :as sql]
+    [jsonista.core :as json]
     [migratus.core :as migratus]
     [next.jdbc :as jdbc]
     [next.jdbc.prepare :as prepare]

--- a/src/framework/session/core.clj
+++ b/src/framework/session/core.clj
@@ -9,9 +9,7 @@
     [xiana.core :as xiana])
   (:import
     (java.util
-      UUID)
-    (org.postgresql.util
-      PGobject)))
+      UUID)))
 
 ;; define session protocol
 (defprotocol Session

--- a/src/framework/session/core.clj
+++ b/src/framework/session/core.clj
@@ -3,6 +3,7 @@
   (:require
     [clojure.string :as string]
     [framework.db.core :as db]
+    [honeysql.format :as sqlf]
     [jsonista.core :as json]
     [next.jdbc.result-set :refer [as-kebab-maps]]
     [xiana.core :as xiana])
@@ -25,40 +26,12 @@
   ;; erase all elements (side effect)
   (erase! [_]))
 
-(def mapper (json/object-mapper {:decode-key-fn keyword}))
-(def ->json json/write-value-as-string)
-(def <-json #(json/read-value % mapper))
-
-(defn ->pgobject
-  "Transforms Clojure data to a PGobject that contains the data as
-  JSON. PGObject type defaults to `jsonb` but can be changed via
-  metadata key `:pgtype`"
-  [x]
-  (let [pgtype (or (:pgtype (meta x)) "jsonb")]
-    (doto (PGobject.)
-      (.setType pgtype)
-      (.setValue (->json x)))))
-
-(defn <-pgobject
-  "Transform PGobject containing `json` or `jsonb` value to Clojure
-  data."
-  [^PGobject v]
-  (let [type (.getType v)
-        value (.getValue v)]
-    (if (#{"jsonb" "json"} type)
-      (some-> value
-              <-json
-              (with-meta {:pgtype type}))
-      value)))
-
 (defn un-objectify
   [table data]
   (let [{session-data (keyword (name table) "session-data")
          session-id   (keyword (name table) "session-id")
          modified-at  (keyword (name table) "modified-at")} data]
-    {session-id (some-> session-data
-                        <-pgobject
-                        (assoc :modified-at modified-at))}))
+    {session-id (assoc session-data :modified-at modified-at)}))
 
 (defn ->session-data [table rs]
   (when-let [session-data (first rs)]
@@ -88,7 +61,7 @@
                          :where  [:= :session_id k]})
         insert-session (fn [k v] {:insert-into table
                                   :values      [{:session_id   k
-                                                 :session_data (->pgobject v)}]
+                                                 :session_data (sqlf/value v)}]
                                   :upsert      {:on-conflict   [:session_id]
                                                 :do-update-set [:session_data :modified-at]}})
         erase-session-store {:truncate table}


### PR DESCRIPTION
## Marshalling between Clj data and db PGobjects

### Description

Implement the protocols needed to handle conversion between Clj data (ie. HashMaps and Vectors) and jdbc PGobjects (containing JSON/JSONB).

This adds automatic support for DB queries which rely on `json_agg` and similar statements retrieving nested data.