### PR TITLE
Read config values from env keys

### DIFF
--- a/config/test/config.edn
+++ b/config/test/config.edn
@@ -23,4 +23,6 @@
                                       :memory-cost     8
                                       :parallelization 1}
                     :pbkdf2-settings {:type       :sha1     ; Available values: :sha1 and :sha256
-                                      :iterations 100000}}}
+                                      :iterations 100000}}
+ :xiana/test       {:test-value-1 "$property"
+                    :test-value-2 "$something-else | default"}}

--- a/examples/acl/project.clj
+++ b/examples/acl/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.4.0-rc3"]]
+                 [com.flexiana/framework "0.4.0-rc4"]]
   :plugins []
   :jvm-opts ["-Dmalli.registry/type=custom"]
   :main ^:skip-aot acl

--- a/examples/cli-chat/project.clj
+++ b/examples/cli-chat/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.4.0-rc3"]]
+                 [com.flexiana/framework "0.4.0-rc4"]]
   :plugins []
   :main ^:skip-aot cli-chat.core
   :uberjar-name "cli-chat.jar"

--- a/examples/controllers/project.clj
+++ b/examples/controllers/project.clj
@@ -3,7 +3,7 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/clojurescript "1.11.4"]
-                 [com.flexiana/framework "0.4.0-rc3"]]
+                 [com.flexiana/framework "0.4.0-rc4"]]
   :plugins [[lein-shadow "0.4.0"]
             [lein-shell "0.5.0"]
             [migratus-lein "0.7.3"]]

--- a/examples/frames/project.clj
+++ b/examples/frames/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.4.0-rc3"]]
+                 [com.flexiana/framework "0.4.0-rc4"]]
   :plugins [[lein-shadow "0.4.0"]]
   :main ^:skip-aot frames.core
   :uberjar-name "frames.jar"

--- a/examples/sessions/project.clj
+++ b/examples/sessions/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.4.0-rc3"]]
+                 [com.flexiana/framework "0.4.0-rc4"]]
   :plugins [[lein-shadow "0.3.1"]
             [lein-shell "0.5.0"]
             [migratus-lein "0.7.3"]]

--- a/examples/state-events/project.clj
+++ b/examples/state-events/project.clj
@@ -3,7 +3,7 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/clojurescript "1.11.4"]
-                 [com.flexiana/framework "0.4.0-rc3"]
+                 [com.flexiana/framework "0.4.0-rc4"]
                  [thheller/shadow-cljs "2.17.7"]
                  [org.clojure/tools.namespace "1.2.0"]
                  [tick "0.5.0-RC5"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.flexiana/framework "0.4.0-rc3"
+(defproject com.flexiana/framework "0.4.0-rc4"
   :description "Framework"
   :url "https://github.com/Flexiana/framework"
   :license {:name "FIXME" :url "FIXME"}

--- a/src/framework/config/core.clj
+++ b/src/framework/config/core.clj
@@ -20,7 +20,7 @@
 
 (defn key-and-default [v]
   (let [[key-name default] (str/split v #"\|")]
-    [(keyword (subs key-name 1)) (some-> default str/trim)]))
+    [(keyword (subs (str/trim key-name) 1)) (some-> default str/trim)]))
 
 (defn- inject-env-vars
   [config]

--- a/src/framework/config/core.clj
+++ b/src/framework/config/core.clj
@@ -3,6 +3,7 @@
   (:require
     [clojure.edn :as edn]
     [clojure.java.io :as io]
+    [clojure.string :as str]
     [config.core :refer [load-env]]
     [xiana.commons :refer [deep-merge]])
   (:import
@@ -17,6 +18,20 @@
       (deep-merge config (edn/read (PushbackReader. r))))
     config))
 
+(defn key-and-default [v]
+  (let [[key-name default] (str/split v #"\|")]
+    [(keyword (subs key-name 1)) (some-> default str/trim)]))
+
+(defn- inject-env-vars
+  [config]
+  (into {} (map (fn mapper [[k v]]
+                  (cond
+                    (map? v) [k (into {} (map mapper v))]
+                    (and (string? v) (str/starts-with? v "$")) (let [[_key default] (key-and-default v)]
+                                                                 [k (get config _key default)])
+                    :else [k v]))
+                config)))
+
 (defn config
   "Returns a new config instance.
 
@@ -28,4 +43,5 @@
   ([config]
    (-> (load-env)
        (deep-merge config)
-       read-edn-file)))
+       read-edn-file
+       inject-env-vars)))

--- a/test/framework/config/core_test.clj
+++ b/test/framework/config/core_test.clj
@@ -53,3 +53,9 @@
            (get-in config [:xiana/postgresql])))
     (is (= {:host "", :user "", :pass "", :tls true, :port 587, :from "xiana@"}
            (get-in config [:xiana/emails])))))
+
+(deftest read-value-from-env
+  (is (= {:test-value-1 nil, :test-value-2 "default"}
+         (:xiana/test (config/config))))
+  (is (= {:test-value-1 "test-property", :test-value-2 "default"}
+         (:xiana/test (config/config {:property "test-property"})))))

--- a/test/framework/config/core_test.clj
+++ b/test/framework/config/core_test.clj
@@ -55,7 +55,13 @@
            (get-in config [:xiana/emails])))))
 
 (deftest read-value-from-env
+  ;; pls break it via executing:
+  ;; env SOMETHING_ELSE='else' lein test
+  ;; env PROPERTY='something' lein test
+
   (is (= {:test-value-1 nil, :test-value-2 "default"}
          (:xiana/test (config/config))))
   (is (= {:test-value-1 "test-property", :test-value-2 "default"}
-         (:xiana/test (config/config {:property "test-property"})))))
+         (:xiana/test (config/config {:property "test-property"}))))
+  (is (= {:test-value-1 nil, :test-value-2 "test-property"}
+         (:xiana/test (config/config {:something-else "test-property"})))))


### PR DESCRIPTION
## Title: With this change you can define a config value to read it from environment variable, or read add a default value instead.

### Description
This PR makes possible to have configuration defined in a way like
```clojure
  :email-address "$frankie-email | no-reply@frankie.com"
```
It's try to solve the `FRANKIE_EMAIL` key from already existing config keys 
 - properties
 - env
 - config.edn
 - file from :config key
 - file from :framework-edn-config key

If it finds, then inject it, if doesn't it's use `no-reply@frankie.com` as default.
If no default provided and no variable set for the key, it sets it up as `nil`
### Tester info
new test provided for read value from env-variable