### PR TITLE
hide server implementation

### DIFF
--- a/examples/acl/project.clj
+++ b/examples/acl/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.4.0-rc3"]]
+                 [com.flexiana/framework "0.4.0-rc4"]]
   :plugins []
   :main ^:skip-aot acl
   :uberjar-name "acl.jar"

--- a/examples/cli-chat/project.clj
+++ b/examples/cli-chat/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.4.0-rc3"]]
+                 [com.flexiana/framework "0.4.0-rc4"]]
   :plugins []
   :main ^:skip-aot cli-chat.core
   :uberjar-name "cli-chat.jar"

--- a/examples/cli-chat/src/backend/cli_chat/views/chat.clj
+++ b/examples/cli-chat/src/backend/cli_chat/views/chat.clj
@@ -1,13 +1,13 @@
 (ns cli-chat.views.chat
   (:require
     [clojure.string :as str]
-    [ring.adapter.jetty9 :as jetty]
+    [framework.websockets.core :as ws]
     [xiana.core :as xiana]))
 
 (defn send-multi-line
   ([ch reply]
    (doseq [m (str/split-lines reply)]
-     (jetty/send! ch (str m "\n"))))
+     (ws/send! ch (str m "\n"))))
   ([{{req-ch :ch}    :request-data
      {res-ch :ch
       reply  :reply} :response-data}]
@@ -18,7 +18,7 @@
      channels :channels} :request-data
     {reply :reply}       :response-data}]
   (doseq [c (remove #(#{ch} (key %)) @channels)]
-    (jetty/send! (key c) reply)))
+    (ws/send! (key c) reply)))
 
 (defn broadcast
   [{{ch         :ch

--- a/examples/controllers/project.clj
+++ b/examples/controllers/project.clj
@@ -3,7 +3,7 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/clojurescript "1.11.4"]
-                 [com.flexiana/framework "0.4.0-rc3"]]
+                 [com.flexiana/framework "0.4.0-rc4"]]
   :plugins [[lein-shadow "0.4.0"]
             [lein-shell "0.5.0"]
             [migratus-lein "0.7.3"]]

--- a/examples/frames/project.clj
+++ b/examples/frames/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.4.0-rc3"]]
+                 [com.flexiana/framework "0.4.0-rc4"]]
   :plugins [[lein-shadow "0.4.0"]]
   :main ^:skip-aot frames.core
   :uberjar-name "frames.jar"

--- a/examples/sessions/project.clj
+++ b/examples/sessions/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
-                 [com.flexiana/framework "0.4.0-rc3"]]
+                 [com.flexiana/framework "0.4.0-rc4"]]
   :plugins [[lein-shadow "0.3.1"]
             [lein-shell "0.5.0"]
             [migratus-lein "0.7.3"]]

--- a/examples/state-events/project.clj
+++ b/examples/state-events/project.clj
@@ -3,7 +3,7 @@
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [org.clojure/clojurescript "1.11.4"]
-                 [com.flexiana/framework "0.4.0-rc3"]
+                 [com.flexiana/framework "0.4.0-rc4"]
                  [thheller/shadow-cljs "2.17.7"]
                  [re-frame "1.2.0"]
                  [cljs-ajax "0.8.4"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.flexiana/framework "0.4.0-rc3"
+(defproject com.flexiana/framework "0.4.0-rc4"
   :description "Framework"
   :url "https://github.com/Flexiana/framework"
   :license {:name "FIXME" :url "FIXME"}

--- a/src/framework/websockets/core.clj
+++ b/src/framework/websockets/core.clj
@@ -5,8 +5,12 @@
     [clojure.string :as str]
     [framework.interceptor.queue :as queue]
     [reitit.core :as r]
+    [ring.adapter.jetty9 :as jetty]
     [taoensso.timbre :as log]
     [xiana.core :as xiana]))
+
+(def send! jetty/send!)
+(def close! jetty/close!)
 
 (defn string->
   "String to 'uri', uses the first word as action key"

--- a/test/framework/web_socket/integration_test.clj
+++ b/test/framework/web_socket/integration_test.clj
@@ -6,8 +6,8 @@
     [framework-fixture :as fixture]
     [framework.handler.core :refer [handler-fn]]
     [framework.interceptor.core :as interceptors]
-    [framework.websockets.core :as ws]
     [framework.rbac.core :as rbac]
+    [framework.websockets.core :as ws]
     [http.async.client :as a-client]
     [taoensso.timbre :as log]
     [xiana.core :as xiana])

--- a/test/framework/web_socket/integration_test.clj
+++ b/test/framework/web_socket/integration_test.clj
@@ -6,10 +6,9 @@
     [framework-fixture :as fixture]
     [framework.handler.core :refer [handler-fn]]
     [framework.interceptor.core :as interceptors]
+    [framework.websockets.core :as ws]
     [framework.rbac.core :as rbac]
-    [framework.session.core :as session]
     [http.async.client :as a-client]
-    [ring.adapter.jetty9 :as jetty]
     [taoensso.timbre :as log]
     [xiana.core :as xiana])
   (:import
@@ -21,11 +20,11 @@
     (assoc-in state [:response-data :channel]
               {:on-text    (fn [ch msg]
                              (log/info "Message: " msg)
-                             (jetty/send! ch msg))
+                             (ws/send! ch msg))
                :on-bytes   (fn [ch msg _offset _len]
                              (log/info "Message: " msg)
-                             (jetty/send! ch msg))
-               :on-error   (fn [ch _e] (jetty/close! ch))
+                             (ws/send! ch msg))
+               :on-error   (fn [ch _e] (ws/close! ch))
                :on-close   (fn [_ch _status _reason]
                              (log/info "\nCLOSE=============="))
                :on-connect (fn [ch]


### PR DESCRIPTION
## Title: Apps should not know about web server implementation

### Description
All `jetty` related codes wrapped in the corresponding name space of Xiana

### Tester info
both `lein test` and `./example-test.sh` should be green