### PR TITLE
Feature/175 remove testing utilities from production code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ Breaking changes:
 - changed interceptors behaviour making them similar to pedestal and sieppari
 - changed error handling
 - addded deps.edn
-- a bunch of other small fixes.
+- a bunch of other small fixes
+- removed `docker-postgres!` function.
 
 ## 0.5-rc1
 Breaking change: rename almost all namespaces from `framework..` to `xiana..`).

--- a/dev/utils.clj
+++ b/dev/utils.clj
@@ -1,0 +1,23 @@
+(ns utils
+  (:require
+    [clj-test-containers.core :as tc]))
+
+(defn docker-postgres!
+  [{pg-config :xiana/postgresql :as config}]
+  (let [{:keys [dbname user password image-name]} pg-config
+        container (-> (tc/create
+                        {:image-name    image-name
+                         :exposed-ports [5432]
+                         :env-vars      {"POSTGRES_DB"       dbname
+                                         "POSTGRES_USER"     user
+                                         "POSTGRES_PASSWORD" password}})
+                      (tc/start!))
+        port (get (:mapped-ports container) 5432)
+        pg-config (assoc
+                    pg-config
+                    :port port
+                    :embedded container
+                    :subname (str "//localhost:" port "/" dbname))]
+    (tc/wait {:wait-strategy :log
+              :message       "accept connections"} (:container container))
+    (assoc config :xiana/postgresql pg-config)))

--- a/examples/acl/project.clj
+++ b/examples/acl/project.clj
@@ -13,6 +13,8 @@
              :prod  {:resource-paths ["config/prod"]}
              :test  {:resource-paths ["config/test"]
                      :dependencies   [[clj-http "3.12.3"]
+                                      [clj-test-containers "0.6.0"]
+                                      [org.testcontainers/testcontainers "1.16.3"]
                                       [mvxcvi/cljstyle "0.15.0"
                                        :exclusions [org.clojure/clojure]]]}}
   :aliases {"check-style" ["with-profile" "+test" "run" "-m" "cljstyle.main" "check"]

--- a/examples/acl/test/acl_fixture.clj
+++ b/examples/acl/test/acl_fixture.clj
@@ -1,13 +1,33 @@
 (ns acl-fixture
   (:require
     [acl]
-    [xiana.config :as config]
-    [xiana.db :as db]))
+    [clj-test-containers.core :as tc]
+    [xiana.config :as config]))
+
+(defn docker-postgres!
+  [{pg-config :xiana/postgresql :as config}]
+  (let [{:keys [dbname user password image-name]} pg-config
+        container (-> (tc/create
+                        {:image-name    image-name
+                         :exposed-ports [5432]
+                         :env-vars      {"POSTGRES_DB"       dbname
+                                         "POSTGRES_USER"     user
+                                         "POSTGRES_PASSWORD" password}})
+                      (tc/start!))
+        port (get (:mapped-ports container) 5432)
+        pg-config (assoc
+                    pg-config
+                    :port port
+                    :embedded container
+                    :subname (str "//localhost:" port "/" dbname))]
+    (tc/wait {:wait-strategy :log
+              :message       "accept connections"} (:container container))
+    (assoc config :xiana/postgresql pg-config)))
 
 (defn std-system-fixture
   [f]
   (with-open [_ (-> (config/config)
                     (merge acl/app-cfg)
-                    db/docker-postgres!
+                    docker-postgres!
                     acl/->system)]
     (f)))

--- a/examples/cli-chat/project.clj
+++ b/examples/cli-chat/project.clj
@@ -13,6 +13,8 @@
              :prod  {:resource-paths ["config/prod"]}
              :test  {:resource-paths ["config/test"]
                      :dependencies   [[clj-http "3.12.3"]
+                                      [clj-test-containers "0.6.0"]
+                                      [org.testcontainers/testcontainers "1.16.3"]
                                       [http.async.client "1.3.1"]
                                       [mvxcvi/cljstyle "0.15.0"
                                        :exclusions [org.clojure/clojure]]]}}

--- a/examples/cli-chat/test/cli_chat_fixture.clj
+++ b/examples/cli-chat/test/cli_chat_fixture.clj
@@ -1,13 +1,33 @@
 (ns cli-chat-fixture
   (:require
     [cli-chat.core :refer [->system]]
-    [xiana.config :as config]
-    [xiana.db :as db]))
+    [clj-test-containers.core :as tc]
+    [xiana.config :as config]))
+
+(defn docker-postgres!
+  [{pg-config :xiana/postgresql :as config}]
+  (let [{:keys [dbname user password image-name]} pg-config
+        container (-> (tc/create
+                        {:image-name    image-name
+                         :exposed-ports [5432]
+                         :env-vars      {"POSTGRES_DB"       dbname
+                                         "POSTGRES_USER"     user
+                                         "POSTGRES_PASSWORD" password}})
+                      (tc/start!))
+        port (get (:mapped-ports container) 5432)
+        pg-config (assoc
+                    pg-config
+                    :port port
+                    :embedded container
+                    :subname (str "//localhost:" port "/" dbname))]
+    (tc/wait {:wait-strategy :log
+              :message       "accept connections"} (:container container))
+    (assoc config :xiana/postgresql pg-config)))
 
 (defn std-system-fixture
   [app-cfg f]
   (with-open [_ (-> (config/config)
                     (merge app-cfg)
-                    db/docker-postgres!
+                    docker-postgres!
                     ->system)]
     (f)))

--- a/examples/sessions/project.clj
+++ b/examples/sessions/project.clj
@@ -18,6 +18,8 @@
              :prod  {:resource-paths ["config/prod"]}
              :test  {:resource-paths ["config/test"]
                      :dependencies   [[clj-http "3.12.3"]
+                                      [clj-test-containers "0.6.0"]
+                                      [org.testcontainers/testcontainers "1.16.3"]
                                       [mvxcvi/cljstyle "0.15.0"
                                        :exclusions [org.clojure/clojure]]]}}
   :shadow-cljs {:nrepl {:port 8777}

--- a/examples/sessions/test/integration_test.clj
+++ b/examples/sessions/test/integration_test.clj
@@ -2,6 +2,7 @@
   (:require
     [app.core :as app]
     [clj-http.client :as http]
+    [clj-test-containers.core :as tc]
     [clojure.test :refer [deftest is use-fixtures]]
     [jsonista.core :as json]
     [next.jdbc :as jdbc]
@@ -11,6 +12,26 @@
   (:import
     (java.util
       UUID)))
+
+(defn docker-postgres!
+  [{pg-config :xiana/postgresql :as config}]
+  (let [{:keys [dbname user password image-name]} pg-config
+        container (-> (tc/create
+                        {:image-name    image-name
+                         :exposed-ports [5432]
+                         :env-vars      {"POSTGRES_DB"       dbname
+                                         "POSTGRES_USER"     user
+                                         "POSTGRES_PASSWORD" password}})
+                      (tc/start!))
+        port (get (:mapped-ports container) 5432)
+        pg-config (assoc
+                    pg-config
+                    :port port
+                    :embedded container
+                    :subname (str "//localhost:" port "/" dbname))]
+    (tc/wait {:wait-strategy :log
+              :message       "accept connections"} (:container container))
+    (assoc config :xiana/postgresql pg-config)))
 
 (defn merge-connection
   [config]
@@ -23,7 +44,7 @@
   (with-open [system (-> (config/config app/app-cfg)
                          (assoc :xiana/postgresql (:xiana/session-backend (config/config)))
                          (assoc-in [:xiana/postgresql :image-name] "postgres:14-alpine")
-                         db/docker-postgres!
+                         docker-postgres!
                          db/connect
                          merge-connection
                          app/->system)]

--- a/examples/state-events/project.clj
+++ b/examples/state-events/project.clj
@@ -2,6 +2,8 @@
   :description "FIXME: write description"
   :min-lein-version "2.0.0"
   :dependencies [[com.flexiana/framework "0.5.0-rc2"]
+                 [clj-test-containers "0.6.0"]
+                 [org.testcontainers/testcontainers "1.16.3"]
                  [tick "0.5.0-RC5"]]
   :main ^:skip-aot state-events.core
   :uberjar-name "state-events.jar"

--- a/project.clj
+++ b/project.clj
@@ -2,6 +2,7 @@
   :description "Xiana framework"
   :url "https://github.com/Flexiana/framework"
   :license {:name "FIXME" :url "FIXME"}
+  :plugins [[lein-pprint "1.1.1"]]
   :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/core.async "1.5.648"]
                  [org.clojure/data.json "2.4.0"] ; TODO: remove this or jsonista
@@ -36,7 +37,7 @@
              :local    {:resource-paths ["config/local"]}
              :prod     {:resource-paths ["config/prod"]}
              :cljstyle {:dependencies []}
-             :test     {:source-paths   ["test"]
+             :test     {:source-paths   ["test" "dev"]
                         :resource-paths ["config/test"]
                         :dependencies   [[lambdaisland/kaocha "1.64.1010"]
                                          [clj-http "3.12.3"]

--- a/project.clj
+++ b/project.clj
@@ -19,8 +19,6 @@
                  [nilenso/honeysql-postgres "0.4.112"]
                  [org.postgresql/postgresql "42.3.3"]
                  [seancorfield/next.jdbc "1.2.659"]
-                 [clj-test-containers "0.6.0"]
-                 [org.testcontainers/testcontainers "1.16.3"]
                  [yogthos/config "1.2.0"]
                  [com.taoensso/timbre "5.2.1"]]
   :source-paths ["src"]
@@ -46,6 +44,8 @@
                                          [mvxcvi/cljstyle "0.15.0"
                                           :exclusions [org.clojure/clojure]]
                                          [clj-kondo "2022.03.09"]
+                                         [clj-test-containers "0.6.0"]
+                                         [org.testcontainers/testcontainers "1.16.3"]
                                          [nubank/matcher-combinators "3.3.1"]]}}
   :aliases {"check-style" ["with-profile" "+test" "run" "-m" "cljstyle.main" "check"]
             "fix-style"   ["with-profile" "+test" "run" "-m" "cljstyle.main" "fix"]

--- a/src/xiana/db.clj
+++ b/src/xiana/db.clj
@@ -1,7 +1,6 @@
 (ns xiana.db
   "Data source builder"
   (:require
-    [clj-test-containers.core :as tc]
     [honeysql-postgres.format]
     [honeysql.core :as sql]
     [jsonista.core :as json]
@@ -95,25 +94,6 @@
                                (get-datasource config (inc count))
                                (throw e)))))))
 
-(defn docker-postgres!
-  [{pg-config :xiana/postgresql :as config}]
-  (let [{:keys [dbname user password image-name]} pg-config
-        container (-> (tc/create
-                        {:image-name    image-name
-                         :exposed-ports [5432]
-                         :env-vars      {"POSTGRES_DB"       dbname
-                                         "POSTGRES_USER"     user
-                                         "POSTGRES_PASSWORD" password}})
-                      (tc/start!))
-        port (get (:mapped-ports container) 5432)
-        pg-config (assoc
-                    pg-config
-                    :port port
-                    :embedded container
-                    :subname (str "//localhost:" port "/" dbname))]
-    (tc/wait {:wait-strategy :log
-              :message       "accept connections"} (:container container))
-    (assoc config :xiana/postgresql pg-config)))
 
 (defn migrate!
   ([config]

--- a/src/xiana/db.clj
+++ b/src/xiana/db.clj
@@ -94,7 +94,6 @@
                                (get-datasource config (inc count))
                                (throw e)))))))
 
-
 (defn migrate!
   ([config]
    (migrate! config 0))

--- a/test/xiana_fixture.clj
+++ b/test/xiana_fixture.clj
@@ -1,6 +1,7 @@
 (ns xiana-fixture
   (:require
     [piotr-yuxuan.closeable-map :refer [closeable-map]]
+    [utils]
     [xiana.commons :refer [rename-key]]
     [xiana.config :as config]
     [xiana.db :as db-core]
@@ -15,7 +16,7 @@
   (-> (config/config)
       (merge app-cfg)
       (rename-key :xiana/auth :auth)
-      db-core/docker-postgres!
+      utils/docker-postgres!
       db-core/connect
       db-core/migrate!
       session-backend/init-backend


### PR DESCRIPTION
## Title: Remove testing utilities from production code

### Description
1. Moved function `docker-postgres!` from production code to `dev/utils` namespace, which is only part of test profile. 
2. Copied `docker-postgres!` to example projects, which are using it. 

The reason for this change is that presence of the function in question was forcing clients to depend on test-containers.

### Tester info
A brief description of any steps needed to demonstrate the new functionality or show the bug is fixed

### Completion Checklist

- [x] Add description of the changes made here to the changelop file
- [ ] Update the documentation as necessary
