### PR TITLE
[229] Creates interceptor to dissoc GET request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## [Unreleased] - 2022-06-25 
+## [Unreleased] - 2022-06-26
+- Added new `prune-get-request-bodies` interceptor
+
 Breaking changes: 
 - refactor database migration system, use patched migratus (Flexiana/migratus), removed seed module and rewrite data migration tool
 

--- a/doc/interceptors.md
+++ b/doc/interceptors.md
@@ -12,6 +12,7 @@
 - [rbac](#rbac)
 - [coercion](#coercion)
 - [cookies](#cookies)
+- [prune-get-request-bodies](#prune-get-request-bodies)
 
 ## log
 
@@ -70,3 +71,7 @@ On `:leave`, validates the response body with the given malli schema.
 ## cookies
 
     Cookie request/response wrapper
+
+## prune-get-request-bodies
+
+On `:enter`, removes both `body` and `:body-params` from GET requests.

--- a/src/xiana/interceptor.clj
+++ b/src/xiana/interceptor.clj
@@ -130,3 +130,14 @@
   "Muuntaja encoder/decoder interceptor."
   ([] (muuntaja muuntaja/interceptor))
   ([interceptor] interceptor))
+
+(defn- get-request? [{:keys [request-method]}]
+  (= :get request-method))
+
+(def prune-get-request-bodies
+  "This interceptor removes bodies from GET requests on Enter."
+  {:name ::prune-get-bodies
+   :enter (fn [{:keys [request] :as state}]
+            (if (get-request? request)
+              (update state :request dissoc :body :body-params)
+              state))})

--- a/test/xiana/interceptor_test.clj
+++ b/test/xiana/interceptor_test.clj
@@ -156,3 +156,14 @@
 (deftest contains-muuntaja-interceptor
   (let [interceptor (interceptor/muuntaja)]
     (is (seq interceptor))))
+
+(deftest prunes-get-request-bodies
+  (testing "GET request"
+    (let [state {:request sample-request}]
+      (is (= state (fetch-execute state interceptor/prune-get-request-bodies :enter)))
+      (is (= state (fetch-execute (assoc-in state [:request :body] "TEST BODY") interceptor/prune-get-request-bodies :enter)))
+      (is (= state (fetch-execute (assoc-in state [:request :body-params] {:param "value"}) interceptor/prune-get-request-bodies :enter)))))
+  (testing "POST request"
+    (let [request (-> sample-request (assoc :body {:param1 1 :param2 2}) (assoc :request-method :post))
+          state {:request request}]
+      (is (= state (fetch-execute state interceptor/prune-get-request-bodies :enter))))))


### PR DESCRIPTION
## Title: [229] Creates interceptor to dissoc GET request bodies

### Description
After discussion on Frankie's ticket [[2639]](https://www.notion.so/flexiana/2639-Ensure-malformed-GET-requests-are-rejected-8b309bd7005b4e83b961205813e967a9), the team decided to create an utility interceptor on Xiana that removed bodies from GET requests if included into the pipeline.

### Tester info
Run `lein test`. Test `prunes-get-request-bodies` must pass.

### Completion Checklist

- [x] Add description of the changes made here to the changelop file
- [x] Update the documentation as necessary