### PR TITLE
Add support for custom datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add support for custom datasource
 - JWT signing support for authentication and content exchange via interceptors.
 
 ## 0.5.0-rc3

--- a/config/dev/config.edn
+++ b/config/dev/config.edn
@@ -4,6 +4,18 @@
                     :dbtype   "postgresql"
                     :user     "postgres"
                     :password "postgres"}
+
+ :xiana/hikari-pool-params {:auto-commit        true
+                            :read-only          false
+                            :connection-timeout 30000
+                            :validation-timeout 5000
+                            :idle-timeout       600000
+                            :max-lifetime       1800000
+                            :minimum-idle       10
+                            :maximum-pool-size  10
+                            :pool-name          "db-pool"
+                            :register-mbeans    false}
+
  :xiana/web-server {:port  3000
                     :join? false}
  :xiana/migration  {:store                :database
@@ -16,10 +28,10 @@
                     :tls  true
                     :port 587
                     :from ""}
- :xiana/auth       {:hash-algorithm  :bcrypt                ; Available values: :bcrypt, :scrypt, and :pbkdf2
+ :xiana/auth       {:hash-algorithm  :bcrypt ; Available values: :bcrypt, :scrypt, and :pbkdf2
                     :bcrypt-settings {:work-factor 11}
                     :scrypt-settings {:cpu-cost        32768 ; Must be a power of 2
                                       :memory-cost     8
                                       :parallelization 1}
-                    :pbkdf2-settings {:type       :sha1     ; Available values: :sha1 and :sha256
+                    :pbkdf2-settings {:type       :sha1 ; Available values: :sha1 and :sha256
                                       :iterations 100000}}}

--- a/config/test/config.edn
+++ b/config/test/config.edn
@@ -5,6 +5,19 @@
                     :dbtype     "postgresql"
                     :user       "postgres"
                     :password   "postgres"}
+
+
+ :xiana/hikari-pool-params {:auto-commit        true
+                            :read-only          false
+                            :connection-timeout 30000
+                            :validation-timeout 5000
+                            :idle-timeout       600000
+                            :max-lifetime       1800000
+                            :minimum-idle       10
+                            :maximum-pool-size  10
+                            :pool-name          "db-pool"
+                            :register-mbeans    false}
+
  :xiana/web-server {:port  3333
                     :join? false}
  :xiana/migration  {:store                :database
@@ -17,12 +30,12 @@
                     :tls  true
                     :port 587
                     :from ""}
- :xiana/auth       {:hash-algorithm  :bcrypt                ; Available values: :bcrypt, :scrypt, and :pbkdf2
+ :xiana/auth       {:hash-algorithm  :bcrypt ; Available values: :bcrypt, :scrypt, and :pbkdf2
                     :bcrypt-settings {:work-factor 11}
                     :scrypt-settings {:cpu-cost        32768 ; Must be a power of 2
                                       :memory-cost     8
                                       :parallelization 1}
-                    :pbkdf2-settings {:type       :sha1     ; Available values: :sha1 and :sha256
+                    :pbkdf2-settings {:type       :sha1 ; Available values: :sha1 and :sha256
                                       :iterations 100000}}
  :xiana/test       {:test-value-1 "$property"
                     :test-value-2 "$something-else | default"}}

--- a/deps.edn
+++ b/deps.edn
@@ -4,7 +4,6 @@
          org.clojure/tools.cli                   {:mvn/version "1.0.206"}
          org.clojure/data.json                   {:mvn/version "2.4.0"},
          org.clojure/data.xml                    {:mvn/version "0.0.8"},
-
          com.draines/postal                      {:mvn/version "2.0.5"},
          com.flexiana/tiny-rbac                  {:mvn/version "0.1.1"},
          com.taoensso/timbre                     {:mvn/version "5.2.1"},
@@ -24,7 +23,8 @@
          org.postgresql/postgresql               {:mvn/version "42.3.3"},
          piotr-yuxuan/closeable-map              {:mvn/version "0.35.0"},
          seancorfield/next.jdbc                  {:mvn/version "1.2.659"},
-         yogthos/config                          {:mvn/version "1.2.0"}}
+         yogthos/config                          {:mvn/version "1.2.0"}
+         hikari-cp/hikari-cp                     {:mvn/version "3.0.1"}}
 
  :aliases
  {:dev


### PR DESCRIPTION
## Add support for custom datasource

### Description
The support for custom datasource is needed for using some database connection pool, or for creating custom database access (in Frankie we need both). 
Maybe the name `:xiana/create-custom-datasource` is not the best, I can take other suggestions. 🤔 

### Tester info
- Check whether the everything is working as before
- Check whether using the `:xiana/create-custom-datasource` will create the right datasource with the defined jdbc options.

### Completion Checklist

- [x] Add description of the changes made here to the changelog file
- [x] Update the documentation as necessary (is it needed in this case?)
