### PR TITLE
New interceptors and updates to existing ones

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -24,7 +24,9 @@
          piotr-yuxuan/closeable-map              {:mvn/version "0.35.0"},
          seancorfield/next.jdbc                  {:mvn/version "1.2.659"},
          yogthos/config                          {:mvn/version "1.2.0"}
-         hikari-cp/hikari-cp                     {:mvn/version "3.0.1"}}
+         hikari-cp/hikari-cp                     {:mvn/version "3.0.1"}
+         org.slf4j/slf4j-simple                  {:mvn/version "2.0.7"}
+         camel-snake-kebab/camel-snake-kebab     {:mvn/version "0.4.3"}}
 
  :aliases
  {:dev

--- a/deps.edn
+++ b/deps.edn
@@ -66,6 +66,8 @@
   {:extra-paths ["config/test" "test"]
    :extra-deps  {clj-test-containers/clj-test-containers {:mvn/version "0.5.0"}
                  clj-http/clj-http                       {:mvn/version "3.12.3"}
+                 ring/ring-mock                          {:mvn/version "0.4.0"}
+                 peridot/peridot                         {:mvn/version "0.5.4"}
                  http.async.client/http.async.client     {:mvn/version "1.3.1"}
                  com.cognitect/test-runner               {:git/url "https://github.com/cognitect-labs/test-runner"
                                                           :sha     "4e7e1c0dfd5291fa2134df052443dc29695d8cbe"}

--- a/src/xiana/interceptor.clj
+++ b/src/xiana/interceptor.clj
@@ -5,6 +5,7 @@
     [clojure.walk :refer [keywordize-keys]]
     [malli.core :as m]
     [malli.transform :as mt]
+    [ring.middleware.multipart-params :refer [multipart-params-request]]
     [ring.middleware.params :as middleware.params]
     [xiana.interceptor.muuntaja :as muuntaja]
     [xiana.session :as session])
@@ -53,9 +54,9 @@
   Leave: nil."
   {:name  ::params
    :enter (fn [state]
-            (let [f #(keywordize-keys
-                       ((middleware.params/wrap-params identity) %))]
-              (update state :request f)))})
+            (let [wrap-params #(keywordize-keys
+                                 ((middleware.params/wrap-params identity) %))]
+              (update state :request (comp wrap-params multipart-params-request))))})
 
 (defn message                                               ; TODO: remove, use logger
   "This interceptor creates a function that prints predefined message.
@@ -68,7 +69,7 @@
 (defn session-user-id
   "This interceptor handles the session user id management.
   Enter: Get the session id from the request header, if
-  that operation doesn't succeeds a new session is created an associated to the
+  that operation doesn't succeed a new session is created an associated to the
   current state, otherwise the cached session data is used.
   Leave: Verify if the state has a session id, if so add it to
   the session instance and remove the new session property of the current state.

--- a/src/xiana/interceptor.clj
+++ b/src/xiana/interceptor.clj
@@ -170,11 +170,16 @@
                                     (not-empty (get-in state [:request :multipart-params]))
                                     (not-empty (get-in state [:request :body-params])))
                     method (get-in state [:request :request-method])
-                    schemas (or (get-in state [:request-data :match :data method :parameters])
-                                (get-in state [:request-data :match :data :parameters]))
-                    cc (cond
-                         (:path schemas) (valid? (:path schemas) path)
-                         (:query schemas) (valid? (:query schemas) query)
-                         (:form schemas) (valid? (:form schemas) form-params))]
 
+                    schemas (merge (get-in state [:request-data :match :data :parameters])
+                                   (get-in state [:request-data :match :data method :parameters]))
+                    cc (cond-> {}
+                         (:path schemas)
+                         (assoc :path (valid? (:path schemas) path))
+
+                         (:query schemas)
+                         (assoc :query (valid? (:query schemas) query))
+
+                         (:form schemas)
+                         (assoc :form (valid? (:form schemas) form-params)))]
                 (update-in state [:request :params] merge cc))))})

--- a/src/xiana/interceptor/cors.clj
+++ b/src/xiana/interceptor/cors.clj
@@ -1,0 +1,26 @@
+(ns xiana.interceptor.cors)
+
+(defn cors-headers [origin]
+  {"Access-Control-Allow-Origin"      origin
+   "Access-Control-Allow-Credentials" "true"
+   "Access-Control-Allow-Methods"     "GET,PUT,POST,DELETE"
+   "Access-Control-Allow-Headers"     "Origin, X-Requested-With, Content-Type, Accept"})
+
+(defn preflight?
+  "Returns true if the request is a preflight request"
+  [request]
+  (= (request :request-method) :options))
+
+(def interceptor
+  {:name  ::cross-origin-headers
+   :leave (fn [state]
+            (let [request (:request state)
+                  headers (cors-headers (get-in state [:deps :cors-origin]))]
+              (if (preflight? request)
+                (update-in state [:response]
+                           merge
+                           {:status  200
+                            :headers headers
+                            :body    "preflight complete"})
+                (update-in state [:response :headers]
+                           merge headers))))})

--- a/src/xiana/interceptor/error.clj
+++ b/src/xiana/interceptor/error.clj
@@ -1,12 +1,13 @@
-(ns xiana.interceptor.error)
+(ns xiana.interceptor.error
+  (:require [ring.util.response :as ring]))
 
 (def response
   "Handles the exception if there's `ex-info` exception with non-empty
   `:xiana/response` key."
-  {:name ::response
+  {:name  ::error-response
    :error (fn [state]
             (if-let [resp (-> state :error ex-data :xiana/response)]
               (-> state
-                  (assoc :response resp)
+                  (assoc :response (ring/bad-request resp))
                   (dissoc :error))
               state))})

--- a/src/xiana/interceptor/error.clj
+++ b/src/xiana/interceptor/error.clj
@@ -9,6 +9,6 @@
    :error (fn [state]
             (if-let [resp (-> state :error ex-data :xiana/response)]
               (-> state
-                  (assoc :response (ring/bad-request resp))
+                  (assoc :response resp)
                   (dissoc :error))
               state))})

--- a/src/xiana/interceptor/error.clj
+++ b/src/xiana/interceptor/error.clj
@@ -1,5 +1,6 @@
 (ns xiana.interceptor.error
-  (:require [ring.util.response :as ring]))
+  (:require
+    [ring.util.response :as ring]))
 
 (def response
   "Handles the exception if there's `ex-info` exception with non-empty

--- a/src/xiana/interceptor/error.clj
+++ b/src/xiana/interceptor/error.clj
@@ -1,6 +1,4 @@
-(ns xiana.interceptor.error
-  (:require
-    [ring.util.response :as ring]))
+(ns xiana.interceptor.error)
 
 (def response
   "Handles the exception if there's `ex-info` exception with non-empty

--- a/src/xiana/interceptor/kebab_camel.clj
+++ b/src/xiana/interceptor/kebab_camel.clj
@@ -1,7 +1,8 @@
 (ns xiana.interceptor.kebab-camel
-  (:require [camel-snake-kebab.core :as csk]
-            [camel-snake-kebab.extras :as cske]
-            [clojure.core.memoize :as mem]))
+  (:require
+    [camel-snake-kebab.core :as csk]
+    [camel-snake-kebab.extras :as cske]
+    [clojure.core.memoize :as mem]))
 
 (def interceptor
   "The purpose is to make Js request compatible with clojure, and response compatible with Javascript.
@@ -9,9 +10,9 @@
   {:name  ::camel-to-kebab-case
    :enter (fn [state]
             (update-in state [:request :params]
-                        (fn [resp]
-                          (cske/transform-keys
-                            (mem/fifo csk/->kebab-case {} :fifo/threshold 512) resp))))
+                       (fn [resp]
+                         (cske/transform-keys
+                           (mem/fifo csk/->kebab-case {} :fifo/threshold 512) resp))))
    :leave (fn [state]
             (update-in state [:response :body]
                        (fn [resp]

--- a/src/xiana/interceptor/kebab_camel.clj
+++ b/src/xiana/interceptor/kebab_camel.clj
@@ -1,0 +1,19 @@
+(ns xiana.interceptor.kebab-camel
+  (:require [camel-snake-kebab.core :as csk]
+            [camel-snake-kebab.extras :as cske]
+            [clojure.core.memoize :as mem]))
+
+(def interceptor
+  "The purpose is to make Js request compatible with clojure, and response compatible with Javascript.
+  :request - {:params { "
+  {:name  ::camel-to-kebab-case
+   :enter (fn [state]
+            (update-in state [:request :params]
+                        (fn [resp]
+                          (cske/transform-keys
+                            (mem/fifo csk/->kebab-case {} :fifo/threshold 512) resp))))
+   :leave (fn [state]
+            (update-in state [:response :body]
+                       (fn [resp]
+                         (cske/transform-keys
+                           (mem/fifo csk/->camelCase {} :fifo/threshold 512) resp))))})

--- a/src/xiana/jwt/interceptors.clj
+++ b/src/xiana/jwt/interceptors.clj
@@ -43,7 +43,6 @@
          :else
          (helpers/unauthorized state "Signature could not be verified."))))})
 
-
 (def jwt-content
   {:name ::jwt-content-exchange
    :enter

--- a/test/resources/multipart.csv
+++ b/test/resources/multipart.csv
@@ -1,0 +1,5 @@
+first_name,last_name,age
+John,Doe,25
+Jane,Doe,24
+Alice,Smith,22
+Bob,Johnson,30

--- a/test/xiana/interceptor/cors_test.clj
+++ b/test/xiana/interceptor/cors_test.clj
@@ -1,0 +1,28 @@
+(ns xiana.interceptor.cors-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [xiana.interceptor.cors :refer [cors-headers interceptor]]))
+
+(deftest cors-interceptor-test
+  (testing "cross-origin-headers interceptor"
+    (let [leave (:leave interceptor)
+          origin "http://localhost:3001"]
+
+      (testing "when request is a preflight request"
+        (let [state {:request {:request-method :options}
+                     :deps    {:cors-origin origin}}
+              expected (update-in state [:response]
+                                  merge
+                                  {:status  200
+                                   :headers (cors-headers origin)
+                                   :body    "preflight complete"})
+              result (leave state)]
+          (is (= expected result))))
+
+      (testing "when request is not a preflight request"
+        (let [state {:request  {:request-method :get}
+                     :deps     {:cors-origin origin}
+                     :response {:headers {}}}
+              expected (update-in state [:response :headers]
+                                  merge (cors-headers origin))
+              result (leave state)]
+          (is (= expected result)))))))

--- a/test/xiana/interceptor/cors_test.clj
+++ b/test/xiana/interceptor/cors_test.clj
@@ -1,6 +1,7 @@
 (ns xiana.interceptor.cors-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [xiana.interceptor.cors :refer [cors-headers interceptor]]))
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [xiana.interceptor.cors :refer [cors-headers interceptor]]))
 
 (deftest cors-interceptor-test
   (testing "cross-origin-headers interceptor"

--- a/test/xiana/interceptor/error_test.clj
+++ b/test/xiana/interceptor/error_test.clj
@@ -1,7 +1,8 @@
 (ns xiana.interceptor.error-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [ring.util.response :as ring]
-            [xiana.interceptor.error :refer [response]]))
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [ring.util.response :as ring]
+    [xiana.interceptor.error :refer [response]]))
 
 (defn make-error-state [response]
   {:error (ex-info "Test exception" {:xiana/response response})})

--- a/test/xiana/interceptor/error_test.clj
+++ b/test/xiana/interceptor/error_test.clj
@@ -1,0 +1,20 @@
+(ns xiana.interceptor.error-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ring.util.response :as ring]
+            [xiana.interceptor.error :refer [response]]))
+
+(defn make-error-state [response]
+  {:error (ex-info "Test exception" {:xiana/response response})})
+
+(deftest response-test
+  (testing "Error response interceptor"
+    (let [resp {:error "Test error"}
+          error-state (make-error-state resp)
+          f (:error response)
+          result (f error-state)]
+      (is (= {:response (ring/bad-request resp)} result))
+
+      (testing "When :error is nil"
+        (let [error-state {:error nil}
+              result (f error-state)]
+          (is (= {:error nil} result)))))))

--- a/test/xiana/interceptor/error_test.clj
+++ b/test/xiana/interceptor/error_test.clj
@@ -1,7 +1,6 @@
 (ns xiana.interceptor.error-test
   (:require
     [clojure.test :refer [deftest is testing]]
-    [ring.util.response :as ring]
     [xiana.interceptor.error :refer [response]]))
 
 (defn make-error-state [response]
@@ -13,7 +12,7 @@
           error-state (make-error-state resp)
           f (:error response)
           result (f error-state)]
-      (is (= {:response (ring/bad-request resp)} result))
+      (is (= {:response resp} result))
 
       (testing "When :error is nil"
         (let [error-state {:error nil}

--- a/test/xiana/interceptor/kebab_camel_test.clj
+++ b/test/xiana/interceptor/kebab_camel_test.clj
@@ -1,0 +1,19 @@
+(ns xiana.interceptor.kebab-camel-test
+  (:require [clojure.test :refer [deftest is testing]])
+  (:require [xiana.interceptor.kebab-camel :as kc]))
+
+(deftest req->kebab-resp->camel-test
+  (testing "Transforms keys of request params to kebab case"
+    (let [state {:request {:params {:paramKey1 1 :paramKey2 2 :paramKey3 3}}}
+          expected {:request {:params {:param-key-1 1 :param-key-2 2 :param-key-3 3}}}
+          enter (:enter kc/interceptor)
+          result (enter state)]
+      (is (= expected result))))
+
+  (testing "Transform keys of response body to Camel case"
+    (let [state {:response {:body {:param-key-1 1 :param-key-2 2 :param-key-3 3}}}
+          expected {:response {:body {:paramKey1 1 :paramKey2 2 :paramKey3 3}}}
+          leave (:leave kc/interceptor)
+          result (leave state)]
+      (is (= expected result)))))
+

--- a/test/xiana/interceptor/kebab_camel_test.clj
+++ b/test/xiana/interceptor/kebab_camel_test.clj
@@ -1,6 +1,7 @@
 (ns xiana.interceptor.kebab-camel-test
-  (:require [clojure.test :refer [deftest is testing]])
-  (:require [xiana.interceptor.kebab-camel :as kc]))
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [xiana.interceptor.kebab-camel :as kc]))
 
 (deftest req->kebab-resp->camel-test
   (testing "Transforms keys of request params to kebab case"

--- a/test/xiana/interceptor/multipart_test.clj
+++ b/test/xiana/interceptor/multipart_test.clj
@@ -5,7 +5,9 @@
     [peridot.multipart :as p]
     [ring.mock.request :as mock]
     [xiana.interceptor :as interceptor])
-  (:import (java.io File)))
+  (:import
+    (java.io
+      File)))
 
 (defn state []
   {:request

--- a/test/xiana/interceptor/multipart_test.clj
+++ b/test/xiana/interceptor/multipart_test.clj
@@ -1,0 +1,25 @@
+(ns xiana.interceptor.multipart-test
+  (:require
+    [clojure.java.io :as io]
+    [clojure.test :refer [deftest is testing]]
+    [peridot.multipart :as p]
+    [ring.mock.request :as mock]
+    [xiana.interceptor :as interceptor])
+  (:import (java.io File)))
+
+(defn state []
+  {:request
+   (merge (mock/request :post "/upload")
+          (p/build {:data (io/file "test/resources/multipart.csv")}))})
+
+(deftest multipart-test
+  (testing "Multipart support in the Framework interceptor chain"
+    (let [f (:enter interceptor/params)
+          r (f (state))
+          data-params (get-in r [:request :params :data])]
+      (is (= "multipart.csv" (:filename data-params)))
+      (is (= "text/csv" (:content-type data-params)))
+      (is (instance? File (:tempfile data-params)))
+      (is (pos? (:size data-params)))
+      (is (= "first_name,last_name,age\nJohn,Doe,25\nJane,Doe,24\nAlice,Smith,22\nBob,Johnson,30\n"
+             (slurp (:tempfile data-params)))))))

--- a/test/xiana/interceptor/wrap_test.clj
+++ b/test/xiana/interceptor/wrap_test.clj
@@ -59,17 +59,17 @@
       (wrap/middleware->enter middleware/wrap-format-request)
       (wrap/middleware->leave middleware/wrap-format-response)))
 
-(deftest contains-midleware-enter
+(deftest contains-middleware-enter
   (let [enter (:enter (wrap/middleware->enter middleware/wrap-format-request))
         result (enter sample-state)]
     ;; verify middleware identity
     (is (= result sample-state))))
 
-(deftest contains-midleware-leave
+(deftest contains-middleware-leave
   (let [leave (:leave (wrap/middleware->leave middleware/wrap-format-request))]
     (is (function? leave))))
 
-(deftest contains-middleware-formated-response-body
+(deftest contains-middleware-formatted-response-body
   (is (= ByteArrayInputStream
          (-> ((:leave middleware-interceptor) sample-state)
              :response

--- a/test/xiana/interceptor_test.clj
+++ b/test/xiana/interceptor_test.clj
@@ -94,7 +94,8 @@
         request (fetch-execute state interceptor/params :enter)
         expected {:request {:form-params  {},
                             :params       {},
-                            :query-params {}}}]
+                            :query-params {}
+                            :multipart-params {}}}]
     ;; expected request value?
     (is (= request expected))))
 

--- a/test/xiana/jwt/interceptors_test.clj
+++ b/test/xiana/jwt/interceptors_test.clj
@@ -1,8 +1,9 @@
 (ns xiana.jwt.interceptors-test
-  (:require [clojure.test :refer [deftest is testing]]
-            [xiana.jwt :as jwt]
-            [xiana.jwt.interceptors :refer [jwt-auth]]
-            [xiana.route.helpers :as helpers]))
+  (:require
+    [clojure.test :refer [deftest is testing]]
+    [xiana.jwt :as jwt]
+    [xiana.jwt.interceptors :refer [jwt-auth]]
+    [xiana.route.helpers :as helpers]))
 
 (defn mock-jwt-verify [_ _ _] "mocky")
 

--- a/test/xiana/jwt/interceptors_test.clj
+++ b/test/xiana/jwt/interceptors_test.clj
@@ -1,0 +1,57 @@
+(ns xiana.jwt.interceptors-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [xiana.jwt :as jwt]
+            [xiana.jwt.interceptors :refer [jwt-auth]]
+            [xiana.route.helpers :as helpers]))
+
+(defn mock-jwt-verify [_ _ _] "mocky")
+
+(defn mock-unauthorized [state _]
+  (assoc state :unauthorized true))
+
+(deftest jwt-auth-test
+  (with-redefs [jwt/verify-jwt mock-jwt-verify
+                helpers/unauthorized mock-unauthorized]
+
+    (testing "jwt-authentication interceptor"
+      (let [enter-fn (:enter jwt-auth)
+            error-fn (:error jwt-auth)
+            auth-token "your-auth-token"
+            jwt-cfg {:auth "auth-config"}]
+
+        (testing "enter function - with :options request method"
+          (let [state {:request {:request-method :options}}
+                result (enter-fn state)]
+            (is (= state result))))
+
+        (testing "enter function - with authorization in headers"
+          (let [state {:request {:request-method :get
+                                 :headers        {:authorization (str "Bearer " auth-token)}}}
+                expected (assoc-in state [:session-data :jwt-authentication] (jwt/verify-jwt :claims auth-token jwt-cfg))
+                result (enter-fn state)]
+            (is (= expected result))))
+
+        (testing "enter function - without authorization in headers"
+          (let [state {:request {:request-method :get
+                                 :headers        {:authorization nil}}}
+                expected "Authorization header not provided"
+                result (enter-fn state)]
+            (is (= expected (.getMessage (:error result))))))
+
+        (testing "error function - with :exp cause"
+          (let [state {:error (ex-info "Error message" {:cause :exp})}
+                expected (helpers/unauthorized state "JWT Token expired.")
+                result (error-fn state)]
+            (is (= expected result))))
+
+        (testing "error function - with :validation type"
+          (let [state {:error (ex-info "Error message" {:type :validation})}
+                expected (helpers/unauthorized state "One or more Claims were invalid.")
+                result (error-fn state)]
+            (is (= expected result))))
+
+        (testing "error function - with other error type"
+          (let [state {:error (ex-info "Error message" {:type :other})}
+                expected (helpers/unauthorized state "Signature could not be verified.")
+                result (error-fn state)]
+            (is (= expected result))))))))

--- a/test/xiana/jwt_test.clj
+++ b/test/xiana/jwt_test.clj
@@ -1,7 +1,8 @@
 (ns xiana.jwt-test
   (:require
     [clojure.test :refer [deftest testing is]]
-    [xiana.jwt :as sut]))
+    [xiana.jwt :as sut])
+  (:import (clojure.lang ExceptionInfo)))
 
 (def private-key-file "test/resources/_files/jwtRS256.key")
 (def public-key-file "test/resources/_files/jwtRS256.key.pub")
@@ -35,7 +36,7 @@
     (sut/verify-jwt type
                     (sut/sign type payload cfg)
                     cfg)
-    (catch clojure.lang.ExceptionInfo e
+    (catch ExceptionInfo e
       (ex-data e))))
 
 (deftest test-jwt-auth

--- a/test/xiana/jwt_test.clj
+++ b/test/xiana/jwt_test.clj
@@ -2,7 +2,9 @@
   (:require
     [clojure.test :refer [deftest testing is]]
     [xiana.jwt :as sut])
-  (:import (clojure.lang ExceptionInfo)))
+  (:import
+    (clojure.lang
+      ExceptionInfo)))
 
 (def private-key-file "test/resources/_files/jwtRS256.key")
 (def public-key-file "test/resources/_files/jwtRS256.key.pub")

--- a/test/xiana/rbac/integration_test.clj
+++ b/test/xiana/rbac/integration_test.clj
@@ -7,7 +7,7 @@
     [xiana-fixture :as fixture]
     [xiana.handler :refer [handler-fn]]
     [xiana.interceptor :as interceptors]
-    [xiana.interceptor.error]
+    [xiana.interceptor.error :as error]
     [xiana.rbac :as rbac]
     [xiana.session :as session])
   (:import
@@ -52,7 +52,7 @@
   {:routes                  routes
    :session-backend         backend
    :xiana/role-set          role-set
-   :controller-interceptors [xiana.interceptor.error/response
+   :controller-interceptors [error/response
                              interceptors/params
                              session/interceptor
                              rbac/interceptor]})


### PR DESCRIPTION
## New interceptors and updates to existing ones

### CORS headers interceptor

1. The allowed origin is configurable from env variables and in state it looks for `:cors-url` under `:deps` key
2. It also supports `preflight` requests

Error response
Error interceptor wrapped in `bad request` response instead of 200

### Multipart/form-data support

1. Tiny but subtle improvement of params interceptor
2. Mock and Peridot library used for testing purposes as it allows us to simply mock multipart requests, and many others, but that's what we needed at the moment.

### Coercion improvements

1. The first change I propose here is avoiding nesting coercion result under param type (path, query, form) and just keeping it under params
2. Validation error returns humanized details

### kebab-camel request/request - experimental feature, up for discussion

If the back-end is Clojure and Front-end Javascript we encounter inconsistency of keys in the context of the language.
Hence the experimental solution that we can discuss:

1. kebab-camel interceptor transforms each key upon request to kebab:
- original request `{:request {:params {:paramKey1 1 :paramKey2 2 :paramKey3 3}}}`
- request after interceptor `{:request {:params {:param-key-1 1 :param-key-2 2 :param-key-3 3}}}`
          
2. The keys in the response body are also transformed from kebab to camel:
- response before interceptor - `{:response {:body {:param-key-1 1 :param-key-2 2 :param-key-3 3}}}`
- after `{:response {:body {:paramKey1 1 :paramKey2 2 :paramKey3 3}}}`

P.S. `slf4j-simple` is also added to `deps.edn` to finally get rid of warning at the beginning of http server.

### Tester info
All tests are provided

### Completion Checklist

- [ ] Add description of the changes made here to the changelog file
> Will be added after approval
- [ ] Update the documentation as necessary
> The same here