### PR TITLE
Bump ring version and add javax.servlet/servlet-api

### DIFF
--- a/.github/workflows/examples_test.yml
+++ b/.github/workflows/examples_test.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'corretto'
-        java-version: '11'
+        java-version: '17'
 
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@9.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         distribution: 'corretto'
-        java-version: '11'
+        java-version: '17'
 
     - name: Install clojure tools
       uses: DeLaGuardo/setup-clojure@9.4

--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
          com.taoensso/timbre                     {:mvn/version "5.2.1"},
          crypto-password/crypto-password         {:mvn/version "0.3.0"},
          funcool/cuerdas                         {:mvn/version "2.2.1"},
-         info.sunng/ring-jetty9-adapter          {:mvn/version "0.17.5"},
+         info.sunng/ring-jetty9-adapter          {:mvn/version "0.30.1"},
          metosin/malli                           {:mvn/version "0.8.4"},
          metosin/reitit                          {:mvn/version "0.5.18"},
          ;; migratus/migratus               {:mvn/version "1.3.7"},

--- a/deps.edn
+++ b/deps.edn
@@ -27,7 +27,8 @@
          hikari-cp/hikari-cp                     {:mvn/version "3.0.1"}
          org.slf4j/slf4j-simple                  {:mvn/version "2.0.7"}
          camel-snake-kebab/camel-snake-kebab     {:mvn/version "0.4.3"}
-         ring/ring                               {:mvn/version "1.9.6"}
+         ring/ring                               {:mvn/version "1.10.0"}
+         javax.servlet/servlet-api               {:mvn/version "2.5"}
          hiccup/hiccup                           {:mvn/version "1.0.5"}}
 
  :aliases

--- a/examples/frames/project.clj
+++ b/examples/frames/project.clj
@@ -12,7 +12,8 @@
              :local {:resource-paths ["config/local" "resources"]}
              :prod  {:resource-paths ["config/prod" "resources"]}
              :test  {:resource-paths ["config/test" "resources"]
-                     :dependencies   [[mvxcvi/cljstyle "0.15.0"
+                     :dependencies   [[clj-http "3.12.3"]
+                                      [mvxcvi/cljstyle "0.15.0"
                                        :exclusions [org.clojure/clojure]]]}}
   :shadow-cljs {:nrepl  {:port 8777}
 


### PR DESCRIPTION
## Title: Bump ring version and add javax.servlet/servlet-api

### Description
Dependencies for javax.servlet are dropped from ring.

We bumped ring version to 0.10.0 and added javax.servlet/servlet-api 2.5

### Tester info
Test your app as usual and see if it works. Ex. Frankie

