### PR TITLE
Dev/reset migratus

### DIFF
--- a/src/xiana/db/migrate.clj
+++ b/src/xiana/db/migrate.clj
@@ -63,7 +63,7 @@
       (zero? (count arguments)) {:exit-message (error-msg ["Missing action"])}
 
       ;; wrong action
-      (not (#{"migrate" "rollback" "create"} (first arguments))) {:exit-message (error-msg ["Wrong action name"])}
+      (not (#{"migrate" "rollback" "create" "reset"} (first arguments))) {:exit-message (error-msg ["Wrong action name"])}
 
       ;; missing required config opt for migrate and rollback
       (and (some #{"migrate" "rollback"} arguments)
@@ -100,6 +100,10 @@
   ([config] (mig/rollback config))
   ([config id] (mig/rollback-until-just-after config (Long/parseLong id))))
 
+(defn reset
+  [config]
+  (mig/reset config))
+
 (defn create-script
   [dir name]
   (mig/create {:migration-dir dir} name))
@@ -117,6 +121,14 @@
     (if-let [id (:id options)]
       (migrate cfg id)
       (migrate cfg))))
+
+(defn reset-action
+  [options]
+  (log/info "Reset database")
+  (log/debug "options:" options)
+  (let [cfg (get-db-config (load-config options))]
+    (log/debug "config:" cfg)
+    (reset cfg)))
 
 (defn rollback-action
   [options]
@@ -144,7 +156,8 @@
       (case action
         "migrate"  (migrate-action options)
         "rollback" (rollback-action options)
-        "create"   (create-script-action options)))))
+        "create"   (create-script-action options)
+        "reset"    (reset-action options)))))
 
 (defn -main
   [& args]

--- a/src/xiana/swagger.clj
+++ b/src/xiana/swagger.clj
@@ -13,64 +13,70 @@
     [reitit.trie :as trie]
     [ring.util.response]))
 
+
+  ;; "xiana-route->reitit-route is taking route entry of our custom shape of routes
+  ;; and transforms it into proper reitit route entry that is valid on the Swagger
+  ;; implemention of reitit.
+
+  ;; (xiana-route->reitit-route [\"/swagger-ui\" {:action :swagger-ui
+  ;;                                              :some-values true}])
+  ;; ;; => [\"/swagger-ui\"
+  ;;        {:get
+  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+  ;;         :patch
+  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+  ;;         :trace
+  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+  ;;         :connect
+  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+  ;;         :delete
+  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+  ;;         :head
+  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+  ;;         :post
+  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+  ;;         :action :swagger-ui,
+  ;;         :options
+  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+  ;;         :put
+  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+  ;;         :some-values true}]
+  ;; "
+
 (def all-methods
   [:get :patch :trace :connect :delete :head :post :options :put])
 
-(defn xiana-route->reitit-route
-  "xiana-route->reitit-route is taking route entry of our custom shape of routes
-  and transforms it into proper reitit route entry that is valid on the Swagger
-  implemention of reitit.
+(defn- no-method?
+  [opt-map]
+  (:action opt-map))
 
-  (xiana-route->reitit-route [\"/swagger-ui\" {:action :swagger-ui
-                                               :some-values true}])
-  ;; => [\"/swagger-ui\"
-         {:get
-          {:handler #function[clojure.core/identity], :action :swagger-ui},
-          :patch
-          {:handler #function[clojure.core/identity], :action :swagger-ui},
-          :trace
-          {:handler #function[clojure.core/identity], :action :swagger-ui},
-          :connect
-          {:handler #function[clojure.core/identity], :action :swagger-ui},
-          :delete
-          {:handler #function[clojure.core/identity], :action :swagger-ui},
-          :head
-          {:handler #function[clojure.core/identity], :action :swagger-ui},
-          :post
-          {:handler #function[clojure.core/identity], :action :swagger-ui},
-          :action :swagger-ui,
-          :options
-          {:handler #function[clojure.core/identity], :action :swagger-ui},
-          :put
-          {:handler #function[clojure.core/identity], :action :swagger-ui},
-          :some-values true}]
-  "
+(defn- reduce-opt-map
+  [opt-map all-methods]
+  (reduce (fn [acc method]
+            (if (get acc method)
+              (if (get-in acc [method :handler])
+                acc
+                (-> acc
+                    (assoc-in [method :handler] identity)))
+              acc))
+          opt-map
+          all-methods))
+
+(defn- process-opt-map
+  [opt-map all-methods]
+  (if (no-method? opt-map)
+    (-> opt-map
+        (assoc-in [:get :handler] identity)
+        (assoc-in [:get :action] (:action opt-map)))
+    (reduce-opt-map opt-map all-methods)))
+
+
+(defn xiana-route->reitit-route
   [[url opt-map & nested-routes :as route] all-methods]
-  (let [new-opt-map (if (:action opt-map)
-                      (let [action' (:action opt-map)
-                            swagger-base-of-endpoint (:swagger-* opt-map)]
-                        (reduce (fn [acc method]
-                                  (-> acc
-                                      (assoc-in [method :handler] identity)
-                                      (assoc-in [method :action] action')
-                                      (merge swagger-base-of-endpoint)))
-                                opt-map
-                                all-methods))
-                      (let [swagger-base-of-endpoint (get opt-map :swagger-* {})]
-                        (reduce (fn [acc method]
-                                  (if (get acc method)
-                                    (if (get-in acc [method :handler])
-                                      acc
-                                      (-> acc
-                                          (assoc-in [method :handler] identity)
-                                          (merge swagger-base-of-endpoint)))
-                                    acc))
-                                opt-map
-                                all-methods)))]
-    (if (-> route meta :no-doc)
-      nil
-      (apply conj [url new-opt-map]
-             (map #(xiana-route->reitit-route % all-methods) nested-routes)))))
+  (when-not (-> route meta :no-doc)
+    (apply conj
+           [url (process-opt-map opt-map all-methods)]
+           (map #(xiana-route->reitit-route % all-methods) nested-routes))))
 
 (defn xiana-routes->reitit-routes
   "Transforms routes to the proper reitit form."

--- a/src/xiana/swagger.clj
+++ b/src/xiana/swagger.clj
@@ -13,35 +13,34 @@
     [reitit.trie :as trie]
     [ring.util.response]))
 
+;; "xiana-route->reitit-route is taking route entry of our custom shape of routes
+;; and transforms it into proper reitit route entry that is valid on the Swagger
+;; implemention of reitit.
 
-  ;; "xiana-route->reitit-route is taking route entry of our custom shape of routes
-  ;; and transforms it into proper reitit route entry that is valid on the Swagger
-  ;; implemention of reitit.
-
-  ;; (xiana-route->reitit-route [\"/swagger-ui\" {:action :swagger-ui
-  ;;                                              :some-values true}])
-  ;; ;; => [\"/swagger-ui\"
-  ;;        {:get
-  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
-  ;;         :patch
-  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
-  ;;         :trace
-  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
-  ;;         :connect
-  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
-  ;;         :delete
-  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
-  ;;         :head
-  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
-  ;;         :post
-  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
-  ;;         :action :swagger-ui,
-  ;;         :options
-  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
-  ;;         :put
-  ;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
-  ;;         :some-values true}]
-  ;; "
+;; (xiana-route->reitit-route [\"/swagger-ui\" {:action :swagger-ui
+;;                                              :some-values true}])
+;; ;; => [\"/swagger-ui\"
+;;        {:get
+;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+;;         :patch
+;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+;;         :trace
+;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+;;         :connect
+;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+;;         :delete
+;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+;;         :head
+;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+;;         :post
+;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+;;         :action :swagger-ui,
+;;         :options
+;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+;;         :put
+;;         {:handler #function[clojure.core/identity], :action :swagger-ui},
+;;         :some-values true}]
+;; "
 
 (def all-methods
   [:get :patch :trace :connect :delete :head :post :options :put])
@@ -69,7 +68,6 @@
         (assoc-in [:get :handler] identity)
         (assoc-in [:get :action] (:action opt-map)))
     (reduce-opt-map opt-map all-methods)))
-
 
 (defn xiana-route->reitit-route
   [[url opt-map & nested-routes :as route] all-methods]


### PR DESCRIPTION
## Title: Reset action for migratus

### Description
Rewrite reset action for migratus. Cicada-backend uses it.

### Tester info
- create a xiana app with [deps templates](https://github.com/Flexiana/templates)
  ```bash
  clojure -Sdeps '{:deps {io.github.flexiana/templates {:git/sha "b724a0699dc6695f58c5ec6dd2bd0b706a73a6d9"}}}' -Tnew create :template flexiana/xiana :name xiana-test
  ```
- move to the created directory(`xiana-test`)
- launch db
  ```shell
  docker compose up db
  ```
- change in **deps.edn** the framework coordinates to `:local/root` to location (possible '../framework')
  ```clojure
  com.flexiana/framework      {:local/root  "../framework"}
  ```
- start nrepl and start the system
  ```emacs
  cider-jack-in
  ```
  ```clojure
  (start-dev-system)
  ```
- go to browser url `http://localhost:3000/` 3 times
- Using **DBWeaver** or **psql** connect to database and check 3 sessions in `xiana-test` db and `sessions` table
- At the root of `xiana-test` directory run
  ```bash
  clojure -M:migrate reset --config config/dev/config.edn
  ```
- look again the table `sessions` as above and check that there is no sessions

### Completion Checklist

- [ ] Add description of the changes made here to the changelog file
- [ ] Update the documentation as necessary
