### PR TITLE
Bump hiccup/hiccup to version 2.0.0-RC2

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -29,7 +29,7 @@
          camel-snake-kebab/camel-snake-kebab     {:mvn/version "0.4.3"}
          ring/ring                               {:mvn/version "1.10.0"}
          javax.servlet/servlet-api               {:mvn/version "2.5"}
-         hiccup/hiccup                           {:mvn/version "1.0.5"}}
+         hiccup/hiccup                           {:mvn/version "2.0.0-RC2"}}
 
  :aliases
  {:dev


### PR DESCRIPTION
## Title: Bump hiccup version to 2.0

### Description
This bumps hiccup to latest version

### Tester info
All test should pass!

### Completion Checklist

- [ ] Add description of the changes made here to the changelog file
- [ ] Update the documentation as necessary
