### PR TITLE
Add support of Argon2 key derivation function to xiana/hash

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,23 @@
          com.draines/postal                      {:mvn/version "2.0.5"}
          com.flexiana/tiny-rbac                  {:mvn/version "0.1.1"}
          com.taoensso/timbre                     {:mvn/version "5.2.1"}
-         crypto-password/crypto-password         {:mvn/version "0.3.0"}
+
+         ;; This is a temporary solution: the reference repo does not
+         ;; contain a deps.edn or pom.xml manifest.
+         ;; This solution overrides the reference repo as an empty deps.edn
+         ;; file, so the transitive dependencies have been added below.
+         ;; https://clojure.org/reference/deps_edn#deps_deps_manifest
+         crypto-random/crypto-random {:mvn/version "1.2.1"}
+         crypto-equality/crypto-equality {:mvn/version "1.0.1"}
+         org.clojars.amit/commons-codec {:mvn/version "1.8.0"}
+         at.favre.lib/bcrypt {:mvn/version "0.7.0"}
+         com.lambdaworks/scrypt {:mvn/version "1.4.0"}
+         de.mkammerer/argon2-jvm {:mvn/version "2.11"}
+         ;; crypto-password/crypto-password         {:mvn/version "0.3.0"}
+         crypto-password/crypto-password         {:git/url "https://github.com/Flexiana/crypto-password"
+                                                  :sha     "e3f6719b33cd04033ce0c0328b6aef611675e0b6"
+                                                  :deps/manifest :deps}
+
          funcool/cuerdas                         {:mvn/version "2.2.1"}
          info.sunng/ring-jetty9-adapter          {:mvn/version "0.30.1"}
          metosin/malli                           {:mvn/version "0.8.4"}

--- a/deps.edn
+++ b/deps.edn
@@ -7,23 +7,9 @@
          com.draines/postal                      {:mvn/version "2.0.5"}
          com.flexiana/tiny-rbac                  {:mvn/version "0.1.1"}
          com.taoensso/timbre                     {:mvn/version "5.2.1"}
-
-         ;; This is a temporary solution: the reference repo does not
-         ;; contain a deps.edn or pom.xml manifest.
-         ;; This solution overrides the reference repo as an empty deps.edn
-         ;; file, so the transitive dependencies have been added below.
-         ;; https://clojure.org/reference/deps_edn#deps_deps_manifest
-         crypto-random/crypto-random {:mvn/version "1.2.1"}
-         crypto-equality/crypto-equality {:mvn/version "1.0.1"}
-         org.clojars.amit/commons-codec {:mvn/version "1.8.0"}
-         at.favre.lib/bcrypt {:mvn/version "0.7.0"}
-         com.lambdaworks/scrypt {:mvn/version "1.4.0"}
-         de.mkammerer/argon2-jvm {:mvn/version "2.11"}
          ;; crypto-password/crypto-password         {:mvn/version "0.3.0"}
          crypto-password/crypto-password         {:git/url "https://github.com/Flexiana/crypto-password"
-                                                  :sha     "e3f6719b33cd04033ce0c0328b6aef611675e0b6"
-                                                  :deps/manifest :deps}
-
+                                                  :sha     "cfd90d519e09797a97ded565a1e27c0b938771f1"}
          funcool/cuerdas                         {:mvn/version "2.2.1"}
          info.sunng/ring-jetty9-adapter          {:mvn/version "0.30.1"}
          metosin/malli                           {:mvn/version "0.8.4"}

--- a/src/xiana/hash.clj
+++ b/src/xiana/hash.clj
@@ -50,6 +50,18 @@
     (if (= :sha1 (:type pbkdf2-settings))
       "HMAC-SHA1" "HMAC-SHA256")))
 
+(defmethod make :argon2
+  [{{:keys [argon2-settings]
+     :or   {argon2-settings {:iterations      22
+                             :memory-cost     65536
+                             :parallelization 1}}} :deps/auth}
+   password]
+  (argon2/encrypt
+    password
+    (:iterations argon2-settings)
+    (:memory-cost argon2-settings)
+    (:parallelization argon2-settings)))
+
 (defmulti check
   "Validating password."
   dispatch)

--- a/src/xiana/hash.clj
+++ b/src/xiana/hash.clj
@@ -74,3 +74,6 @@
 
 (defmethod check :pbkdf2 [_ password encrypted]
   (hash-p/check password encrypted))
+
+(defmethod check :argon2 [_ password encrypted]
+  (argon2/check password encrypted))

--- a/src/xiana/hash.clj
+++ b/src/xiana/hash.clj
@@ -5,7 +5,8 @@
   (:require
     [crypto.password.bcrypt :as hash-b]
     [crypto.password.pbkdf2 :as hash-p]
-    [crypto.password.scrypt :as hash-s]))
+    [crypto.password.scrypt :as hash-s]
+    [crypto.password.argon2 :as argon2]))
 
 (def supported [:bcrypt :pbkdf2 :scrypt])
 

--- a/src/xiana/hash.clj
+++ b/src/xiana/hash.clj
@@ -8,7 +8,7 @@
     [crypto.password.scrypt :as hash-s]
     [crypto.password.argon2 :as argon2]))
 
-(def supported [:bcrypt :pbkdf2 :scrypt])
+(def supported [:bcrypt :pbkdf2 :scrypt :argon2])
 
 (defn- dispatch
   ([state password]

--- a/src/xiana/hash.clj
+++ b/src/xiana/hash.clj
@@ -3,10 +3,10 @@
   Supported algorithms are bcrypr, pbkdf2, and scrypt.
   The required algorithm should be in (-> state :deps :auth :hash-algorithm)"
   (:require
+    [crypto.password.argon2 :as argon2]
     [crypto.password.bcrypt :as hash-b]
     [crypto.password.pbkdf2 :as hash-p]
-    [crypto.password.scrypt :as hash-s]
-    [crypto.password.argon2 :as argon2]))
+    [crypto.password.scrypt :as hash-s]))
 
 (def supported [:bcrypt :pbkdf2 :scrypt :argon2])
 

--- a/test/xiana/hash_test.clj
+++ b/test/xiana/hash_test.clj
@@ -30,10 +30,6 @@
     (testing-mistake fragment)
     (testing-ok fragment)))
 
-(deftest test-assert-functionality
-  (let [fragment {:deps {:auth {:hash-algorithm :argon2}}}]
-    (is (thrown? java.lang.AssertionError (hash/make fragment password)))))
-
 (deftest hash-behavior
   (let [pwd "not_nil"
         state {:deps {:auth {:hash-algorithm  :bcrypt

--- a/test/xiana/hash_test.clj
+++ b/test/xiana/hash_test.clj
@@ -30,6 +30,11 @@
     (testing-mistake fragment)
     (testing-ok fragment)))
 
+(deftest test-full-functionality-argon2
+  (let [fragment {:deps {:auth {:hash-algorithm :argon2}}}]
+    (testing-mistake fragment)
+    (testing-ok fragment)))
+
 (deftest hash-behavior
   (let [pwd "not_nil"
         state {:deps {:auth {:hash-algorithm  :bcrypt


### PR DESCRIPTION
## Add support of Argon2 key derivation function to xiana/hash

### Description
Include the fork of crypto-password which contains support for argon2 password hashing